### PR TITLE
add MCP server badge

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,6 +2,10 @@
 
 A Model Context Protocol (MCP) server that enables AI assistants to extract transcripts from YouTube videos. Built for integration with Cursor and Claude Desktop, this tool allows AI to analyze and work with YouTube video content directly.
 
+<a href="https://glama.ai/mcp/servers/@MalikElate/yt-description-mcp">
+  <img width="380" height="200" src="https://glama.ai/mcp/servers/@MalikElate/yt-description-mcp/badge" alt="YouTube Transcript Extractor MCP server" />
+</a>
+
 ## Features
 
 - 🎯 Extract transcripts from any public YouTube video
@@ -107,6 +111,3 @@ Contributions are welcome! Please feel free to submit a Pull Request. For major 
 ## License
 
 MIT
-
-
-


### PR DESCRIPTION
This PR adds a badge for the [YouTube Transcript Extractor MCP](https://glama.ai/mcp/servers/@MalikElate/yt-description-mcp) server listing in Glama MCP server directory.

<a href="https://glama.ai/mcp/servers/@MalikElate/yt-description-mcp">
  <img width="380" height="200" src="https://glama.ai/mcp/servers/@MalikElate/yt-description-mcp/badge" alt="YouTube Transcript Extractor MCP server" />
</a>

Glama performs regular codebase and documentation checks to:

* Confirm that the MCP server is working as expected
* Confirm that there are no obvious security issues with dependencies of the server
* Extract server characteristics such as tools, resources, prompts, and required parameters.

This badge helps your users to quickly assess that the MCP server is safe, server capabilities, and instructions for installing the server.